### PR TITLE
Ajeitando lógica de seeding

### DIFF
--- a/backend/internal/handler/listing_image.go
+++ b/backend/internal/handler/listing_image.go
@@ -16,7 +16,7 @@ func CreateListingImage(c *gin.Context) {
 		return
 	}
 
-	img.ID = uuid.NewString()
+	img.ID = uuid.New()
 
 	if err := repository.DB.Create(&img).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create image"})

--- a/backend/internal/models/favorite.go
+++ b/backend/internal/models/favorite.go
@@ -1,10 +1,12 @@
 package models
 
+import "github.com/google/uuid"
+
 type Favorite struct {
-	UserID    string  `json:"user_id" gorm:"type:uuid;primaryKey"`
-	User      User    `json:"user" gorm:"foreignKey:UserID;references:ID"`
-	ListingID string  `json:"listing_id" gorm:"type:uuid;primaryKey"`
-	Listing   Listing `json:"listing" gorm:"foreignKey:ListingID;references:ID"`
+	UserID    string    `json:"user_id" gorm:"type:uuid;primaryKey"`
+	User      User      `json:"user" gorm:"foreignKey:UserID;references:ID"`
+	ListingID uuid.UUID `json:"listing_id" gorm:"type:uuid;primaryKey"`
+	Listing   Listing   `json:"listing" gorm:"foreignKey:ListingID;references:ID"`
 
 	CreatedAt string `json:"created_at" gorm:"default.now()"`
 }

--- a/backend/internal/models/listingImage.go
+++ b/backend/internal/models/listingImage.go
@@ -1,9 +1,11 @@
 package models
 
+import "github.com/google/uuid"
+
 type ListingImage struct {
-	ID        string  `json:"id" gorm:"type: uuid;default:uuid_generate_v4();primary_key"`
-	ListingID string  `json:"listing_id" gorm:"type:uuid;not null"`
-	Listing   Listing `json:"listing" gorm:"foreignKey:ListingID;references:ID"`
-	Src       string  `json:"src" gorm:"not null"`
-	IsPrimary bool    `json:"is_primary" gorm:"default:false"`
+	ID        uuid.UUID `json:"id" gorm:"type: uuid;default:uuid_generate_v4();primary_key"`
+	ListingID uuid.UUID `json:"listing_id" gorm:"type:uuid;not null"`
+	Listing   Listing   `json:"listing" gorm:"foreignKey:ListingID;references:ID"`
+	Src       string    `json:"src" gorm:"not null"`
+	IsPrimary bool      `json:"is_primary" gorm:"default:false"`
 }


### PR DESCRIPTION
Corrigi os seguintes pontos:
- Padronizei os ids dos listings e imagens de listings pra ser uuid.UUID em vez de string
- Corrigi erro de ficar multiplicando as imagens toda vez que o script de seed é rodado (o que acontece quando o código é modificado)