### PR TITLE
pagination on fts search

### DIFF
--- a/backend/internal/repository/database.go
+++ b/backend/internal/repository/database.go
@@ -49,16 +49,18 @@ func Connect() {
 }
 
 
-func SearchListingsFTS(query string) ([]models.Listing, error) {
+func SearchListingsFTS(query string, page, pageSize int) ([]models.Listing, error) {
 	var results []models.Listing
 
 	sql := `
 	SELECT *
 	FROM listings
 	WHERE title_search @@ websearch_to_tsquery(?)
+	ORDER BY ts_rank(title_search, websearch_to_tsquery(?)) DESC
+	LIMIT ? OFFSET ?
 	`
 
-	err := DB.Raw(sql, query).Scan(&results).Error
+	err := DB.Raw(sql, query, query, pageSize, (page-1)*pageSize).Scan(&results).Error
     if err != nil {
 		log.Fatal("❌ Failed to scan listings using fts: ", err)
         return nil, err


### PR DESCRIPTION
busca agora é paginada

3 parametros:

```text
{api}/listings/search?query=busca+pelo+produto&page=2&pageSize=10
```

obs: apenas `query` é um parametro obrigatorio
`page` e `pageSize` são definidos em 1 e 10 respectivamente caso não sejam passados.
`page` começa em 1